### PR TITLE
Scrap pandas

### DIFF
--- a/dtApp/dtCode/crossvalidation.py
+++ b/dtApp/dtCode/crossvalidation.py
@@ -5,14 +5,11 @@ from flask import render_template
 from dtApp import app
 from dtApp import date
 import plotly
-import plotly.graph_objs as go
 from plotly.subplots import make_subplots
-import pandas as pd
-import numpy as np
 import json
 
-from dtLib.crossval.example import tSW,tSO,tSH,tBR,youtSW,youtSO,youtSH,youtBR
-from dtLib.crossval.example import tNumSW,tNumSWmiddle,tNumSO,tNumSH,tNumBR,tNumSHmiddle,youtNumSW,youtNumSO,youtNumSH,youtNumBR
+from dtLib.crossval.extract_data import tSW,tSO,tSH,tBR,youtSW,youtSO,youtSH,youtBR
+from dtLib.crossval.extract_data import tNumSW,tNumSWmiddle,tNumSO,tNumSH,tNumBR,tNumSHmiddle,youtNumSW,youtNumSO,youtNumSH,youtNumBR
 
 @app.route('/crossval')#@app.route('/ExpValidation_Updated')
 def ExpValidation_Updated():
@@ -29,36 +26,36 @@ def Exp_Data():
     subplot_titles=("<b>Prototype 1<b>","<b>Prototype 2<b>", "<b>Prototype 3<b>", "<b>Prototype 4<b>"))
 
     # Fig1.a
-    fig1.add_scatter(x=tSW,y=youtSW[0], name='Acc floor 1', mode = 'lines', row=1, col=1)
-    fig1.add_scatter(x=tSW,y=youtSW[1], name='Acc floor 2', mode = 'lines', row=1, col=1)
-    fig1.add_scatter(x=tSW,y=youtSW[2], name='Acc floor 3', mode = 'lines', row=1, col=1)
+    fig1.add_scatter(x=tSW,y=youtSW[:,0], name='Acc floor 1', mode = 'lines', row=1, col=1)
+    fig1.add_scatter(x=tSW,y=youtSW[:,1], name='Acc floor 2', mode = 'lines', row=1, col=1)
+    fig1.add_scatter(x=tSW,y=youtSW[:,2], name='Acc floor 3', mode = 'lines', row=1, col=1)
     # Update xaxis properties
     fig1.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=15), row=1, col=1)
     # Update yaxis properties
     fig1.update_yaxes(title_text="dB", titlefont=dict(size=15), row=1, col=1)
 
     ## Fig1.b
-    fig1.add_scatter(x=tSO,y=youtSO[0], name='Acc floor 1', mode = 'lines', row=1, col=2)
-    fig1.add_scatter(x=tSO,y=youtSO[1], name='Acc floor 2', mode = 'lines', row=1, col=2)
-    fig1.add_scatter(x=tSO,y=youtSO[2], name='Acc floor 3', mode = 'lines', row=1, col=2)
+    fig1.add_scatter(x=tSO,y=youtSO[:,0], name='Acc floor 1', mode = 'lines', row=1, col=2)
+    fig1.add_scatter(x=tSO,y=youtSO[:,1], name='Acc floor 2', mode = 'lines', row=1, col=2)
+    fig1.add_scatter(x=tSO,y=youtSO[:,2], name='Acc floor 3', mode = 'lines', row=1, col=2)
     # Update xaxis properties
     fig1.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=15), row=1, col=2)
     # Update yaxis properties
     fig1.update_yaxes(title_text="dB", titlefont=dict(size=15), row=1, col=2)
 
     #Fig1.c
-    fig1.add_scatter(x=tSH,y=youtSH[0], name='Acc floor 1', mode = 'lines', row=2, col=1)
-    fig1.add_scatter(x=tSH,y=youtSH[1], name='Acc floor 2', mode = 'lines', row=2, col=1)
-    fig1.add_scatter(x=tSH,y=youtSH[2], name='Acc floor 3', mode = 'lines', row=2, col=1)
+    fig1.add_scatter(x=tSH,y=youtSH[:,0], name='Acc floor 1', mode = 'lines', row=2, col=1)
+    fig1.add_scatter(x=tSH,y=youtSH[:,1], name='Acc floor 2', mode = 'lines', row=2, col=1)
+    fig1.add_scatter(x=tSH,y=youtSH[:,2], name='Acc floor 3', mode = 'lines', row=2, col=1)
     # Update xaxis properties
     fig1.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=15), row=2, col=1)
     # Update yaxis properties
     fig1.update_yaxes(title_text="dB", titlefont=dict(size=15), row=2, col=1)
 
     #Fig1.d
-    fig1.add_scatter(x=tBR,y=youtBR[0], name='Acc floor 1', mode = 'lines', row=2, col=2)
-    fig1.add_scatter(x=tBR,y=youtBR[1], name='Acc floor 2', mode = 'lines', row=2, col=2)
-    fig1.add_scatter(x=tBR,y=youtBR[2], name='Acc floor 3', mode = 'lines', row=2, col=2)
+    fig1.add_scatter(x=tBR,y=youtBR[:,0], name='Acc floor 1', mode = 'lines', row=2, col=2)
+    fig1.add_scatter(x=tBR,y=youtBR[:,1], name='Acc floor 2', mode = 'lines', row=2, col=2)
+    fig1.add_scatter(x=tBR,y=youtBR[:,2], name='Acc floor 3', mode = 'lines', row=2, col=2)
     # Update xaxis properties
     fig1.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=15), row=2, col=2)
     # Update yaxis properties
@@ -87,32 +84,32 @@ def Exp_Num_Data():
     subplot_titles=("<b>Prototype 1<b>","<b>Prototype 2<b>", "<b>Prototype 3<b>", "<b>Prototype 4<b>"))
 
     # Fig3.a
-    fig3.add_scatter(x=tSW,y=youtSW[0], name='Exp Data', mode = 'lines', row=1, col=1)
-    fig3.add_scatter(x=tNumSW,y=youtNumSW[0], name='Num Data', mode = 'markers', marker=dict(size= 1.5), row=1, col=1)
+    fig3.add_scatter(x=tSW,y=youtSW[:,0], name='Exp Data', mode = 'lines', row=1, col=1)
+    fig3.add_scatter(x=tNumSW,y=youtNumSW[:,0], name='Num Data', mode = 'markers', marker=dict(size= 1.5), row=1, col=1)
     # Update xaxis properties
     fig3.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=15), row=1, col=1)
     # Update yaxis properties
     fig3.update_yaxes(title_text="dB", titlefont=dict(size=15),row=1,col=1)
 
     ## Fig3.b
-    fig3.add_scatter(x=tSO,y=youtSO[0], name='Exp Data', mode = 'lines', row=1, col=2)
-    fig3.add_scatter(x=tNumSO,y=youtNumSO[0], name='Num Data', mode = 'markers', marker=dict(size= 1.5), row=1, col=2)
+    fig3.add_scatter(x=tSO,y=youtSO[:,0], name='Exp Data', mode = 'lines', row=1, col=2)
+    fig3.add_scatter(x=tNumSO,y=youtNumSO[:,0], name='Num Data', mode = 'markers', marker=dict(size= 1.5), row=1, col=2)
     # Update xaxis properties
     fig3.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=15), row=1, col=2)
     # Update yaxis properties
     fig3.update_yaxes(title_text="dB", titlefont=dict(size=15),row=1,col=2)
 
     #Fig3.c
-    fig3.add_scatter(x=tSH,y=youtSH[0], name='Exp Data', mode = 'lines', row=2, col=1)
-    fig3.add_scatter(x=tNumSH,y=youtNumSH[0], name='Num Data', mode = 'markers', marker=dict(size= 1.5), row=2, col=1)
+    fig3.add_scatter(x=tSH,y=youtSH[:,0], name='Exp Data', mode = 'lines', row=2, col=1)
+    fig3.add_scatter(x=tNumSH,y=youtNumSH[:,0], name='Num Data', mode = 'markers', marker=dict(size= 1.5), row=2, col=1)
     # Update xaxis properties
     fig3.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=15), row=2, col=1)
     # Update yaxis properties
     fig3.update_yaxes(title_text="dB", titlefont=dict(size=15),row=2,col=1)
 
     #Fig3.d
-    fig3.add_scatter(x=tBR,y=youtBR[0], name='Exp Data', mode = 'lines', row=2, col=2)
-    fig3.add_scatter(x=tNumBR,y=youtNumBR[0], name='Num Data', mode = 'markers', marker=dict(size= 3), row=2, col=2)
+    fig3.add_scatter(x=tBR,y=youtBR[:,0], name='Exp Data', mode = 'lines', row=2, col=2)
+    fig3.add_scatter(x=tNumBR,y=youtNumBR[:,0], name='Num Data', mode = 'markers', marker=dict(size= 3), row=2, col=2)
     # Update xaxis properties
     fig3.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=15), row=2, col=2)
     # Update yaxis properties
@@ -140,36 +137,36 @@ def Num_Data():
     subplot_titles=("<b>Prototype 1<b>","<b>Prototype 2<b>", "<b>Prototype 3<b>", "<b>Prototype 4<b>"))
 
     # Fig2.a
-    fig2.add_scatter(x=tNumSW,y=youtNumSW[0], name='Acc floor 1', mode = 'lines', row=1, col=1)
-    fig2.add_scatter(x=tNumSWmiddle,y=youtNumSW[1], name='Acc floor 2', mode = 'lines', row=1, col=1)
-    fig2.add_scatter(x=tNumSW,y=youtNumSW[2], name='Acc floor 3', mode = 'lines', row=1, col=1)
+    fig2.add_scatter(x=tNumSW,y=youtNumSW[:,0], name='Acc floor 1', mode = 'lines', row=1, col=1)
+    fig2.add_scatter(x=tNumSWmiddle,y=youtNumSW[:,1], name='Acc floor 2', mode = 'lines', row=1, col=1)
+    fig2.add_scatter(x=tNumSW,y=youtNumSW[:,2], name='Acc floor 3', mode = 'lines', row=1, col=1)
     # Update xaxis properties
     fig2.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=15), row=1, col=1)
     # Update yaxis properties
     fig2.update_yaxes(title_text="dB", titlefont=dict(size=15), row=1, col=1)
 
     ## Fig2.b
-    fig2.add_scatter(x=tNumSO,y=youtNumSO[0], name='Acc floor 1', mode = 'lines', row=1, col=2)
-    fig2.add_scatter(x=tNumSO,y=youtNumSO[1], name='Acc floor 2', mode = 'lines', row=1, col=2)
-    fig2.add_scatter(x=tNumSO,y=youtNumSO[2], name='Acc floor 3', mode = 'lines', row=1, col=2)
+    fig2.add_scatter(x=tNumSO,y=youtNumSO[:,0], name='Acc floor 1', mode = 'lines', row=1, col=2)
+    fig2.add_scatter(x=tNumSO,y=youtNumSO[:,1], name='Acc floor 2', mode = 'lines', row=1, col=2)
+    fig2.add_scatter(x=tNumSO,y=youtNumSO[:,2], name='Acc floor 3', mode = 'lines', row=1, col=2)
     # Update xaxis properties
     fig2.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=15), row=1, col=2)
     # Update yaxis properties
     fig2.update_yaxes(title_text="dB", titlefont=dict(size=15), row=1, col=2)
 
     #Fig2.c
-    fig2.add_scatter(x=tNumSH,y=youtNumSH[0], name='Acc floor 1', mode = 'lines', row=2, col=1)
-    fig2.add_scatter(x=tNumSHmiddle,y=youtNumSH[1], name='Acc floor 2', mode = 'lines', row=2, col=1)
-    fig2.add_scatter(x=tNumSH,y=youtNumSH[2], name='Acc floor 3', mode = 'lines', row=2, col=1)
+    fig2.add_scatter(x=tNumSH,y=youtNumSH[:,0], name='Acc floor 1', mode = 'lines', row=2, col=1)
+    fig2.add_scatter(x=tNumSHmiddle,y=youtNumSH[:,1], name='Acc floor 2', mode = 'lines', row=2, col=1)
+    fig2.add_scatter(x=tNumSH,y=youtNumSH[:,2], name='Acc floor 3', mode = 'lines', row=2, col=1)
     # Update xaxis properties
     fig2.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=15), row=2, col=1)
     # Update yaxis properties
     fig2.update_yaxes(title_text="dB", titlefont=dict(size=15), row=2, col=1)
 
     #Fig2.d
-    fig2.add_scatter(x=tNumBR,y=youtNumBR[0], name='Acc floor 1', mode = 'lines', row=2, col=2)
-    fig2.add_scatter(x=tNumBR,y=youtNumBR[1], name='Acc floor 2', mode = 'lines', row=2, col=2)
-    fig2.add_scatter(x=tNumBR,y=youtNumBR[2], name='Acc floor 3', mode = 'lines', row=2, col=2)
+    fig2.add_scatter(x=tNumBR,y=youtNumBR[:,0], name='Acc floor 1', mode = 'lines', row=2, col=2)
+    fig2.add_scatter(x=tNumBR,y=youtNumBR[:,1], name='Acc floor 2', mode = 'lines', row=2, col=2)
+    fig2.add_scatter(x=tNumBR,y=youtNumBR[:,2], name='Acc floor 3', mode = 'lines', row=2, col=2)
     # Update xaxis properties
     fig2.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=15), row=2, col=2)
     # Update yaxis properties
@@ -195,10 +192,10 @@ def Exp_Exp_Data():
     """
     # Figure4
     fig4 = make_subplots(rows=1, cols=1, shared_xaxes=True, vertical_spacing=0.01)
-    fig4.add_scatter(x=tSW,y=youtSW[0], name='Prototype 1 - Exp Data', mode = 'lines', row=1, col=1)
-    fig4.add_scatter(x=tSO,y=youtSO[0], name='Prototype 2 - Exp Data', mode = 'lines', row=1, col=1)
-    fig4.add_scatter(x=tSH,y=youtSH[0], name='Prototype 3 - Exp Data', mode = 'lines', row=1, col=1)
-    fig4.add_scatter(x=tBR,y=youtBR[0], name='Prototype 4 - Exp Data', mode = 'lines', row=1, col=1)
+    fig4.add_scatter(x=tSW,y=youtSW[:,0], name='Prototype 1 - Exp Data', mode = 'lines', row=1, col=1)
+    fig4.add_scatter(x=tSO,y=youtSO[:,0], name='Prototype 2 - Exp Data', mode = 'lines', row=1, col=1)
+    fig4.add_scatter(x=tSH,y=youtSH[:,0], name='Prototype 3 - Exp Data', mode = 'lines', row=1, col=1)
+    fig4.add_scatter(x=tBR,y=youtBR[:,0], name='Prototype 4 - Exp Data', mode = 'lines', row=1, col=1)
     # Update xaxis properties
     fig4.update_xaxes(title_text="Freq (Hz)", titlefont=dict(size=20), row=1, col=1)
     # Update yaxis properties

--- a/dtLib/crossval/data_location.py
+++ b/dtLib/crossval/data_location.py
@@ -1,34 +1,44 @@
-data_location = {
+data_particulars = {
     'experimental':{
         'Swansea':{
             'fullpath':'dtLib/crossval/Data/Experimental Data/ExpDataSw.csv',
+            'slice_range':[0,322],
             },
         'Sheffield':{
             'fullpath':'dtLib/crossval/Data/Experimental Data/ExpDataSh.csv',
+            'slice_range':[0,6561],
             },
         'Southampton':{
             'fullpath':'dtLib/crossval/Data/Experimental Data/ExpDataSo.csv',
+            'slice_range':[0,1313],
             },
         'Bristol':{
             'fullpath':'dtLib/crossval/Data/Experimental Data/ExpDataBr.csv',
+            'slice_range':[0,80002],
             },
     },
     'simulated':{
         'Swansea':{
             'fullpath':'dtLib/crossval/Data/Numerical Data/NumDataSw.csv',
+            'slice_range':[0,3998],
             },
         'Sheffield':{
             'fullpath':'dtLib/crossval/Data/Numerical Data/NumDataSh.csv',
+            'slice_range':[0,3998],
             },
         'Southampton':{
             'fullpath':'dtLib/crossval/Data/Numerical Data/NumDataSo.csv',
+            'slice_range':[0,3992],
             },
         'Bristol':{
             'fullpath':'dtLib/crossval/Data/Numerical Data/NumDataBr.csv',
+            'slice_range':[0,400],
             },
     }
 }
 
+# LimitsExp = np.array([0,322,6561,1313,80002]) #0/Sw/Sh/So/Br
+# LimitsNum = np.array([0,3998,3998,3992,400]) #0/Sw/Sh/So/Br
 
 # dataSwExp = readfile_gen('dtLib/crossval/Data/Experimental Data/ExpDataSw.csv')
 # dataShExp = readfile_gen('dtLib/crossval/Data/Experimental Data/ExpDataSh.csv')

--- a/dtLib/crossval/data_location.py
+++ b/dtLib/crossval/data_location.py
@@ -1,0 +1,41 @@
+data_location = {
+    'experimental':{
+        'Swansea':{
+            'fullpath':'dtLib/crossval/Data/Experimental Data/ExpDataSw.csv',
+            },
+        'Sheffield':{
+            'fullpath':'dtLib/crossval/Data/Experimental Data/ExpDataSh.csv',
+            },
+        'Southampton':{
+            'fullpath':'dtLib/crossval/Data/Experimental Data/ExpDataSo.csv',
+            },
+        'Bristol':{
+            'fullpath':'dtLib/crossval/Data/Experimental Data/ExpDataBr.csv',
+            },
+    },
+    'simulated':{
+        'Swansea':{
+            'fullpath':'dtLib/crossval/Data/Numerical Data/NumDataSw.csv',
+            },
+        'Sheffield':{
+            'fullpath':'dtLib/crossval/Data/Numerical Data/NumDataSh.csv',
+            },
+        'Southampton':{
+            'fullpath':'dtLib/crossval/Data/Numerical Data/NumDataSo.csv',
+            },
+        'Bristol':{
+            'fullpath':'dtLib/crossval/Data/Numerical Data/NumDataBr.csv',
+            },
+    }
+}
+
+
+# dataSwExp = readfile_gen('dtLib/crossval/Data/Experimental Data/ExpDataSw.csv')
+# dataShExp = readfile_gen('dtLib/crossval/Data/Experimental Data/ExpDataSh.csv')
+# dataSoExp = readfile_gen('dtLib/crossval/Data/Experimental Data/ExpDataSo.csv')
+# dataBrExp = readfile_gen('dtLib/crossval/Data/Experimental Data/ExpDataBr.csv')
+
+# dataSwNum = readfile_gen('dtLib/crossval/Data/Numerical Data/NumDataSw.csv')
+# dataShNum = readfile_gen('dtLib/crossval/Data/Numerical Data/NumDataSh.csv')
+# dataSoNum = readfile_gen('dtLib/crossval/Data/Numerical Data/NumDataSo.csv')
+# dataBrNum = readfile_gen('dtLib/crossval/Data/Numerical Data/NumDataBr.csv')

--- a/dtLib/crossval/extract_data.py
+++ b/dtLib/crossval/extract_data.py
@@ -1,0 +1,76 @@
+'''
+This function extracts the experimental and simulated data.
+'''
+import numpy as np
+from typing import Generator
+
+from .data_location import data_location
+
+def readfile_gen(fullpath,sep=','):
+    with open(fullpath,"r") as f:
+        for row in f: yield row.split(sep)
+
+def slice_data(x:Generator,istart:int,iend:int):
+    x_=iter(x)
+    X=[]
+    i=0
+    while True:
+        try: xi = next(x_)
+        except: break
+        if (istart<=i) & (i<=iend): X.append(xi)
+        i+=1
+    return np.asarray(X,dtype=float)
+
+def extract_data(fullpath,istart:int=0,iend:int=10_000): 
+    return slice_data(readfile_gen(fullpath),istart=istart,iend=iend)
+
+LimitsExp = np.array([0,322,6561,1313,80002]) #0/Sw/Sh/So/Br
+LimitsNum = np.array([0,3998,3998,3992,400]) #0/Sw/Sh/So/Br
+
+dataSwExp = extract_data(data_location['experimental']['Swansea']['fullpath'],istart=LimitsExp[0],iend=LimitsExp[1])
+tSW = dataSwExp[:,0]
+youtSW = dataSwExp[:,1:4]
+
+dataShExp = extract_data(data_location['experimental']['Sheffield']['fullpath'],istart=LimitsExp[0],iend=LimitsExp[2])
+tSH = dataShExp[:,0]
+youtSH = dataShExp[:,1:4]
+
+dataSoExp = extract_data(data_location['experimental']['Southampton']['fullpath'],istart=LimitsExp[0],iend=LimitsExp[3])
+tSO = dataSoExp[:,0]
+youtSO = dataSoExp[:,1:4]
+
+dataBrExp = extract_data(data_location['experimental']['Bristol']['fullpath'],istart=LimitsExp[0],iend=LimitsExp[4])
+tBR = dataBrExp[:,0]
+youtBR = dataBrExp[:,1:4]
+
+
+dataSwNum = extract_data(data_location['simulated']['Swansea']['fullpath'],istart=LimitsNum[0],iend=LimitsNum[1])
+tNumSW = dataSwNum[:,0]
+tNumSWmiddle = dataSwNum[:,1]
+youtNumSW = dataSwNum[:,2:]
+
+dataShNum = extract_data(data_location['simulated']['Sheffield']['fullpath'],istart=LimitsNum[0],iend=LimitsNum[2])
+tNumSH = dataShNum[:,0]
+tNumSHmiddle = dataShNum[:,1]
+youtNumSH = dataShNum[:,2:]
+
+dataSoNum = extract_data(data_location['simulated']['Southampton']['fullpath'],istart=LimitsNum[0],iend=LimitsNum[3])
+tNumSO = dataSoNum[:,0]
+tNumSOmiddle = dataSoNum[:,1]
+youtNumSO = dataSoNum[:,1:4]
+
+dataBrNum = extract_data(data_location['simulated']['Bristol']['fullpath'],istart=LimitsNum[0],iend=LimitsNum[4])
+tNumBR = dataBrNum[:,0]
+tNumBRmiddle = dataBrNum[:,1]
+youtNumBR = dataBrNum[:,1:4]
+
+
+# dataSwExp = readfile_gen('dtLib/crossval/Data/Experimental Data/ExpDataSw.csv')
+# dataShExp = readfile_gen('dtLib/crossval/Data/Experimental Data/ExpDataSh.csv')
+# dataSoExp = readfile_gen('dtLib/crossval/Data/Experimental Data/ExpDataSo.csv')
+# dataBrExp = readfile_gen('dtLib/crossval/Data/Experimental Data/ExpDataBr.csv')
+
+# dataSwNum = readfile_gen('dtLib/crossval/Data/Numerical Data/NumDataSw.csv')
+# dataShNum = readfile_gen('dtLib/crossval/Data/Numerical Data/NumDataSh.csv')
+# dataSoNum = readfile_gen('dtLib/crossval/Data/Numerical Data/NumDataSo.csv')
+# dataBrNum = readfile_gen('dtLib/crossval/Data/Numerical Data/NumDataBr.csv')

--- a/dtLib/crossval/extract_data.py
+++ b/dtLib/crossval/extract_data.py
@@ -4,7 +4,7 @@ This function extracts the experimental and simulated data.
 import numpy as np
 from typing import Generator
 
-from .data_location import data_location
+from .data_location import data_particulars
 
 def readfile_gen(fullpath,sep=','):
     with open(fullpath,"r") as f:
@@ -13,56 +13,74 @@ def readfile_gen(fullpath,sep=','):
 def slice_data(x:Generator,istart:int,iend:int):
     x_=iter(x)
     X=[]
+    X_append = X.append
     i=0
     while True:
         try: xi = next(x_)
-        except: break
-        if (istart<=i) & (i<=iend): X.append(xi)
+        except StopIteration: break
+        if (istart<=i) & (i<=iend): X_append(xi)
         i+=1
     return np.asarray(X,dtype=float)
 
 def extract_data(fullpath,istart:int=0,iend:int=10_000): 
     return slice_data(readfile_gen(fullpath),istart=istart,iend=iend)
 
-LimitsExp = np.array([0,322,6561,1313,80002]) #0/Sw/Sh/So/Br
-LimitsNum = np.array([0,3998,3998,3992,400]) #0/Sw/Sh/So/Br
+# LimitsExp = np.array([0,322,6561,1313,80002]) #0/Sw/Sh/So/Br
+# LimitsNum = np.array([0,3998,3998,3992,400]) #0/Sw/Sh/So/Br
 
-dataSwExp = extract_data(data_location['experimental']['Swansea']['fullpath'],istart=LimitsExp[0],iend=LimitsExp[1])
-tSW = dataSwExp[:,0]
-youtSW = dataSwExp[:,1:4]
+################################ Experimental Data ######################
+limits_sw_exp = data_particulars['experimental']['Swansea']['slice_range']
+path_sw_exp = data_particulars['experimental']['Swansea']['fullpath']
+data_sw_exp = extract_data(path_sw_exp,istart=limits_sw_exp[0],iend=limits_sw_exp[1]) # dataSwExp = extract_data(data_particulars['experimental']['Swansea']['fullpath'],istart=LimitsExp[0],iend=LimitsExp[1])
+tSW = data_sw_exp[:,0] # KEEP VARIABLE NAME
+youtSW = data_sw_exp[:,1:4] # KEEP VARIABLE NAME
 
-dataShExp = extract_data(data_location['experimental']['Sheffield']['fullpath'],istart=LimitsExp[0],iend=LimitsExp[2])
-tSH = dataShExp[:,0]
-youtSH = dataShExp[:,1:4]
+limits_sh_exp = data_particulars['experimental']['Sheffield']['slice_range']
+path_sh_exp = data_particulars['experimental']['Sheffield']['fullpath']
+data_sh_exp = extract_data(path_sh_exp,istart=limits_sh_exp[0],iend=limits_sh_exp[1]) # dataShExp = extract_data(data_particulars['experimental']['Sheffield']['fullpath'],istart=LimitsExp[0],iend=LimitsExp[2])
+tSH = data_sh_exp[:,0] # KEEP VARIABLE NAME
+youtSH = data_sh_exp[:,1:4] # KEEP VARIABLE NAME
 
-dataSoExp = extract_data(data_location['experimental']['Southampton']['fullpath'],istart=LimitsExp[0],iend=LimitsExp[3])
-tSO = dataSoExp[:,0]
-youtSO = dataSoExp[:,1:4]
+limits_so_exp = data_particulars['experimental']['Southampton']['slice_range']
+path_so_exp = data_particulars['experimental']['Southampton']['fullpath']
+data_so_exp = extract_data(path_so_exp,istart=limits_so_exp[0],iend=limits_so_exp[1]) # dataSoExp = extract_data(data_particulars['experimental']['Southampton']['fullpath'],istart=LimitsExp[0],iend=LimitsExp[3])
+tSO = data_so_exp[:,0] # KEEP VARIABLE NAME
+youtSO = data_so_exp[:,1:4] # KEEP VARIABLE NAME
 
-dataBrExp = extract_data(data_location['experimental']['Bristol']['fullpath'],istart=LimitsExp[0],iend=LimitsExp[4])
-tBR = dataBrExp[:,0]
-youtBR = dataBrExp[:,1:4]
+limits_br_exp = data_particulars['experimental']['Bristol']['slice_range']
+path_br_exp = data_particulars['experimental']['Bristol']['fullpath']
+data_br_exp = extract_data(path_br_exp,istart=limits_br_exp[0],iend=limits_br_exp[1]) # dataBrExp = extract_data(data_particulars['experimental']['Bristol']['fullpath'],istart=LimitsExp[0],iend=LimitsExp[4])
+tBR = data_br_exp[:,0] # KEEP VARIABLE NAME
+youtBR = data_br_exp[:,1:4] # KEEP VARIABLE NAME
 
+################################ Simulated Data ######################
+limits_sw_num = data_particulars['simulated']['Swansea']['slice_range']
+path_sw_num = data_particulars['simulated']['Swansea']['fullpath']
+data_sw_num = extract_data(path_sw_num,istart=limits_sw_num[0],iend=limits_sw_num[1]) # dataSwNum = extract_data(data_particulars['simulated']['Swansea']['fullpath'],istart=LimitsNum[0],iend=LimitsNum[1])
+tNumSW = data_sw_num[:,0] # KEEP VARIABLE NAME
+tNumSWmiddle = data_sw_num[:,1] 
+youtNumSW = data_sw_num[:,2:] # KEEP VARIABLE NAME
 
-dataSwNum = extract_data(data_location['simulated']['Swansea']['fullpath'],istart=LimitsNum[0],iend=LimitsNum[1])
-tNumSW = dataSwNum[:,0]
-tNumSWmiddle = dataSwNum[:,1]
-youtNumSW = dataSwNum[:,2:]
+limits_sh_num = data_particulars['simulated']['Sheffield']['slice_range']
+path_sh_num = data_particulars['simulated']['Sheffield']['fullpath']
+data_sh_num = extract_data(path_sh_num,istart=limits_sh_num[0],iend=limits_sh_num[1]) # dataShNum = extract_data(data_particulars['simulated']['Sheffield']['fullpath'],istart=LimitsNum[0],iend=LimitsNum[2])
+tNumSH = data_sh_num[:,0] # KEEP VARIABLE NAME
+tNumSHmiddle = data_sh_num[:,1]
+youtNumSH = data_sh_num[:,2:] # KEEP VARIABLE NAME
 
-dataShNum = extract_data(data_location['simulated']['Sheffield']['fullpath'],istart=LimitsNum[0],iend=LimitsNum[2])
-tNumSH = dataShNum[:,0]
-tNumSHmiddle = dataShNum[:,1]
-youtNumSH = dataShNum[:,2:]
+limits_so_num = data_particulars['simulated']['Southampton']['slice_range']
+path_so_num = data_particulars['simulated']['Southampton']['fullpath']
+data_so_num = extract_data(path_so_num,istart=limits_so_num[0],iend=limits_so_num[1])# dataSoNum = extract_data(data_particulars['simulated']['Southampton']['fullpath'],istart=LimitsNum[0],iend=LimitsNum[3])
+tNumSO = data_so_num[:,0] # KEEP VARIABLE NAME
+tNumSOmiddle = data_so_num[:,1]
+youtNumSO = data_so_num[:,1:4] # KEEP VARIABLE NAME
 
-dataSoNum = extract_data(data_location['simulated']['Southampton']['fullpath'],istart=LimitsNum[0],iend=LimitsNum[3])
-tNumSO = dataSoNum[:,0]
-tNumSOmiddle = dataSoNum[:,1]
-youtNumSO = dataSoNum[:,1:4]
-
-dataBrNum = extract_data(data_location['simulated']['Bristol']['fullpath'],istart=LimitsNum[0],iend=LimitsNum[4])
-tNumBR = dataBrNum[:,0]
-tNumBRmiddle = dataBrNum[:,1]
-youtNumBR = dataBrNum[:,1:4]
+limits_br_num = data_particulars['simulated']['Southampton']['slice_range']
+path_br_num = data_particulars['simulated']['Southampton']['fullpath']
+data_br_num = extract_data(path_br_num,istart=limits_br_num[0],iend=limits_br_num[1]) # dataBrNum = extract_data(data_particulars['simulated']['Bristol']['fullpath'],istart=LimitsNum[0],iend=LimitsNum[4])
+tNumBR = data_br_num[:,0] # KEEP VARIABLE NAME
+tNumBRmiddle = data_br_num[:,1]
+youtNumBR = data_br_num[:,1:4] # KEEP VARIABLE NAME
 
 
 # dataSwExp = readfile_gen('dtLib/crossval/Data/Experimental Data/ExpDataSw.csv')


### PR DESCRIPTION
To this date, Pandas is only used to read csv files. While this is done efficiently by the open source library, it feels rather unjustified the use of such beast to only read csv files. 

The action of reading csv files in fact can be done almost as efficiently in pure python, so with no need to require an additional dependency for our project. 

Of course, in the future is pandas is used as database manager composed of flat files, we may reintroduce back this dependency. At the moment there is very little need to keep it, given that we are planning to have SQLAlchemy as data coordinator. In summary, either one or the other. 

